### PR TITLE
Refactor/put records

### DIFF
--- a/src/clj_kinesis_client/core.clj
+++ b/src/clj_kinesis_client/core.clj
@@ -1,5 +1,6 @@
 (ns clj-kinesis-client.core
-  (:require [clojure.data.json :as json])
+  (:require
+    [clojure.data.json :as json])
   (:import
     (com.amazonaws
       ClientConfiguration)
@@ -61,7 +62,8 @@
     (put-record-response->map response)))
 
 
-(defn- put-records-request [stream-name events]
+(defn- put-records-request
+  [stream-name events]
   (let [obj->put-entry (fn [entry]
                          (-> (PutRecordsRequestEntry.)
                              (.withData (->json-byte-buffer entry))
@@ -70,8 +72,9 @@
         (.withStreamName stream-name)
         (.withRecords (map obj->put-entry events)))))
 
+
 (defn put-records
   [client stream-name events]
-  (let [request (put-records-request stream-name events)
-        response (.putRecords client request)]
-    (put-records-response->map response)))
+  (->> (put-records-request stream-name events)
+       (.putRecords client)
+       (put-records-response->map)))

--- a/src/clj_kinesis_client/core.clj
+++ b/src/clj_kinesis_client/core.clj
@@ -61,14 +61,17 @@
     (put-record-response->map response)))
 
 
-(defn put-records
-  [client stream-name events]
+(defn- put-records-request [stream-name events]
   (let [obj->put-entry (fn [entry]
                          (-> (PutRecordsRequestEntry.)
                              (.withData (->json-byte-buffer entry))
-                             (.withPartitionKey (uuid))))
-        request (-> (PutRecordsRequest.)
-                    (.withStreamName stream-name)
-                    (.withRecords (map obj->put-entry events)))
+                             (.withPartitionKey (uuid))))]
+    (-> (PutRecordsRequest.)
+        (.withStreamName stream-name)
+        (.withRecords (map obj->put-entry events)))))
+
+(defn put-records
+  [client stream-name events]
+  (let [request (put-records-request stream-name events)
         response (.putRecords client request)]
     (put-records-response->map response)))


### PR DESCRIPTION
did some refactor to prepare `put-records` to accept more than 500 events. but decided not to do that as I don't want to be responsible for handling the failure cases, e.g. some of the chunk are sent successfully, and some not.

but this refactor is still valid, so I'm leaving it in.